### PR TITLE
Fixed #12, CSS for fields with no value

### DIFF
--- a/FieldtypeColorPicker.module
+++ b/FieldtypeColorPicker.module
@@ -32,7 +32,7 @@ class FieldtypeColorPicker extends Fieldtype {
 	 *
 	 */
 	public function getBlankValue(Page $page, Field $field) {
-		if($field->default == "0") $field->default = "000000";
+		if($field->default === "0") $field->default = "000000";
 		return $field->default ? $field->default : '';
 	}
 
@@ -62,7 +62,7 @@ class FieldtypeColorPicker extends Fieldtype {
 		if(!$field->formatting) return $value;
 
 		if("transp" == strtolower($value)) return self::TRANSPARENT;
-		if($value == "0") $value = "000000";
+		if($value === "0") $value = "000000";
 
 		return self::HEX_PREFIX . $value;
 	}

--- a/colorpicker/css/colorpicker.css
+++ b/colorpicker/css/colorpicker.css
@@ -162,3 +162,9 @@
 .colorpicker_slider {
 	background-position: bottom;
 }
+
+
+.colorpicker_loaded:has(+ input:not([value])),
+.colorpicker_loaded:has(+ input[value=""]) {
+    background: linear-gradient(-45deg, white 47%, red 48%, red 52%, white 53%) !important;
+}


### PR DESCRIPTION
- Fixed https://github.com/somatonic/ColorPicker/issues/12
- Added CSS to distinguish fields with no value (red strike through)

<img width="122" alt="Bildschirmfoto 2022-10-18 um 13 08 37" src="https://user-images.githubusercontent.com/2311113/196417962-c699eb8c-6da0-4b05-8d92-15cbe71ec266.png">
