### PR TITLE
PHP 8.1: Check if value is_null before trim()

### DIFF
--- a/FieldtypeColorPicker.module
+++ b/FieldtypeColorPicker.module
@@ -57,6 +57,7 @@ class FieldtypeColorPicker extends Fieldtype {
 	 */
 	public function ___formatValue(Page $page, Field $field, $value){
 
+		if(is_null($field->default)) $field->default='';
 		if(!$value) $value = trim($field->default);
 		if(!strlen($value)) return $value;
 		if(!$field->formatting) return $value;

--- a/InputfieldColorPicker.module
+++ b/InputfieldColorPicker.module
@@ -62,6 +62,7 @@ class InputfieldColorPicker extends Inputfield {
 		/**
 		 * add swatches for predefined color values | @Rayden
 		 */
+		if(is_null($this->swatch)) $this->swatch='';
 		$swatch = trim($this->swatch);
 
 		if(strlen($swatch)) {


### PR DESCRIPTION
PHP Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecate.